### PR TITLE
Setup InsertEnter autocmd after LspAttach event has fired

### DIFF
--- a/lua/cmp_nvim_lsp/init.lua
+++ b/lua/cmp_nvim_lsp/init.lua
@@ -7,10 +7,17 @@ M.client_source_map = {}
 
 ---Setup cmp-nvim-lsp source.
 M.setup = function()
-  vim.api.nvim_create_autocmd('InsertEnter', {
-    group = vim.api.nvim_create_augroup('cmp_nvim_lsp', { clear = true }),
+  local group = vim.api.nvim_create_augroup('cmp_nvim_lsp', { clear = true })
+  vim.api.nvim_create_autocmd('LspAttach', {
+    group = group,
     pattern = '*',
-    callback = M._on_insert_enter
+    callback = function()
+      vim.api.nvim_create_autocmd('InsertEnter', {
+        group = group,
+        pattern = '*',
+        callback = M._on_insert_enter
+      })
+    end,
   })
 end
 


### PR DESCRIPTION
## Use case
If you want to only load (work) `cmp-nvim-lsp` when the `LspAttach` autocmd fires, but always need  to setup the capabilities.
Currently you cannot get the default (lsp) capabilities (`require("cmp_nvim_lsp").default_capabilities()`) without setting up the entire plugin (=autocmd are created, etc...) (specifically for plugin managers that will source the after directory).

## Solution
Make the plugin be lazy in the sense that you can call `setup` but it won't do anything untill the `LspAttach` autocmd event fires, which means their is an lsp client attached to a buffer.

## Notes!
The `LspAttach` autocmd event was only introduced in [this neovim commit](https://github.com/neovim/neovim/commit/2ffafc7aa9), which is only part of version 0.8. \
I think currently this plugin supports 0.7 still? So if we decide we want this we should announce it on #38.