### PR TITLE
docs: Suggest better ways to configure LSP capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 nvim-cmp source for neovim's built-in language server client.
 
-# Capabilities
+## Capabilities
 
 Language servers provide different completion results depending on the capabilities of the client. Neovim's default omnifunc has basic support for serving completion candidates. nvim-cmp supports more types of completion candidates, so users must override the capabilities sent to the server such that it can provide these candidates during a completion request. These capabilities are provided via the helper function `require('cmp_nvim_lsp').default_capabilities`
 
 As these candidates are sent on each request, **adding these capabilities will break the built-in omnifunc support for neovim's language server client**. `nvim-cmp` provides manually triggered completion that can replace omnifunc. See `:help cmp-faq` for more details.
 
-# Setup
+## Setup
 
 ```lua
 
@@ -18,16 +18,20 @@ require'cmp'.setup {
   }
 }
 
--- The nvim-cmp almost supports LSP's capabilities so You should advertise it to LSP servers..
-local capabilities = require('cmp_nvim_lsp').default_capabilities()
+-- Merge default LSP cabilities with what is supported by nvim-cmp
+local capabilities = vim.tbl_deep_extend("force",
+  vim.lsp.protocol.make_client_capabilities(),
+  require('cmp_nvim_lsp').default_capabilities()
+)
 
--- The following example advertise capabilities to `clangd`.
-require'lspconfig'.clangd.setup {
+-- An example for configuring `clangd` LSP to use nvim-cmp as a completion engine
+require('lspconfig').clangd.setup {
   capabilities = capabilities,
+  ...  -- other lspconfig configs
 }
 ```
 
-# Option
+## Option
 
 `[%LSPCONFIG-NAME%].keyword_pattern`
 
@@ -41,7 +45,7 @@ cmp.setup {
       name = 'nvim_lsp',
       option = {
         php = {
-          keyword_pattern = [=[[\%(\$\k*\)\|\k\+]]=]
+          keyword_pattern = [=[[\%(\$\k*\)\|\k\+]]=],
         }
       }
     }
@@ -51,8 +55,8 @@ cmp.setup {
 ```
 
 
-Readme!
-====================
+## Readme!
+
 1. There is a Github issue that documents [breaking changes](https://github.com/hrsh7th/cmp-nvim-lsp/issues/38) for cmp-nvim-lsp. Subscribe to the issue to be notified of upcoming breaking changes.
 2. This is my hobby project. You can support me via GitHub sponsors.
 3. Bug reports are welcome, but don't expect a fix unless you provide minimal configuration and steps to reproduce your issue.


### PR DESCRIPTION
Using `require('cmp_nvim_lsp').default_capabilities()` alone will be not
enough. We have to merge with the default LSP capabilities produced by
`vim.lsp.protocol.make_client_capabilities()`.

Closes #42
Closes #44