### PR TITLE
Respect `vim.lsp.commands`, `client.commands`, and server capabilities when executing `CompletionItem.command`

### DIFF
--- a/lua/cmp_nvim_lsp/source.lua
+++ b/lua/cmp_nvim_lsp/source.lua
@@ -106,9 +106,7 @@ source.execute = function(self, completion_item, callback)
     return callback()
   end
 
-  self:_request('workspace/executeCommand', completion_item.command, function(_, _)
-    callback()
-  end)
+  self.client:_exec_cmd(completion_item.command, nil, callback, nil)
 end
 
 ---Get object path.


### PR DESCRIPTION
Currently, when cmp-nvim-lsp receives a `CompletionItem` with a `Command`, it executes the command by directly making a `workspace/executeCommand` request.
This behavior fails to respect the user-defined command handlers in `vim.lsp.commands` and `client.commands`, as well as whether the language server is capable of handling the command.
This PR addresses this issue by using the `client:_exec_cmd()` method, which does respect `vim.lsp.commands`, `client.commands`, and server capabilities.

I am aware that `client:_exec_cmd()` is probably meant to be a private method and that relying on it might become a problem in the future.
However, I'm not sure if copying the whole method over to this plugin would be any better, and a [quick search](https://github.com/search?q=language%3Alua+%22%3A_exec_cmd%22+NOT+is%3Afork&type=code&p=1) reveals that there are some plugins that do rely on `client:_exec_method()`.
Please let me know if you have a better idea.