### PR TITLE
Make LSP completions resolve capabilities more spec-compliant

### DIFF
--- a/lua/cmp_nvim_lsp/init.lua
+++ b/lua/cmp_nvim_lsp/init.lua
@@ -54,13 +54,10 @@ M.default_capabilities = function(override)
           insertReplaceSupport = if_nil(override.insertReplaceSupport, true),
           resolveSupport = if_nil(override.resolveSupport, {
               properties = {
-                  "documentation",
-                  "detail",
                   "additionalTextEdits",
                   "sortText",
                   "filterText",
                   "insertText",
-                  "textEdit",
                   "insertTextFormat",
                   "insertTextMode",
               },


### PR DESCRIPTION
Closes https://github.com/hrsh7th/cmp-nvim-lsp/issues/72
Part of https://github.com/rust-lang/rust-analyzer/issues/18504

rust-analyzer started to be more spec-compliant when it comes to completion resolve: 

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion

> Since 3.16.0 the client can signal that it can resolve more properties lazily. This is done using the `completionItem#resolveSupport` client capability which lists all properties that can be filled in during a ‘completionItem/resolve’ request. All other properties (usually `sortText`, `filterText`, `insertText` and `textEdit`) must be provided in the [`textDocument/completion`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_completion) response and must not be changed during resolve.

So, if the editor declares a completion resolve support for the `documentation`, rust-analyzer as a server can omit it in the initial response and now it does so.
