### PR TITLE
Tune LSP completions resolve capabilities to be more immediate

### DIFF
--- a/lua/cmp_nvim_lsp/init.lua
+++ b/lua/cmp_nvim_lsp/init.lua
@@ -56,7 +56,6 @@ M.default_capabilities = function(override)
               properties = {
                   "documentation",
                   "additionalTextEdits",
-                  "insertText",
                   "insertTextFormat",
                   "insertTextMode",
                   "command",

--- a/lua/cmp_nvim_lsp/init.lua
+++ b/lua/cmp_nvim_lsp/init.lua
@@ -55,14 +55,11 @@ M.default_capabilities = function(override)
           resolveSupport = if_nil(override.resolveSupport, {
               properties = {
                   "documentation",
-                  "detail",
                   "additionalTextEdits",
-                  "sortText",
-                  "filterText",
                   "insertText",
-                  "textEdit",
                   "insertTextFormat",
                   "insertTextMode",
+                  "command",
               },
           }),
           insertTextModeSupport = if_nil(override.insertTextModeSupport, {


### PR DESCRIPTION
Follow-up of https://github.com/hrsh7th/cmp-nvim-lsp/pull/75
Closes https://github.com/hrsh7th/cmp-nvim-lsp/issues/72
Part of https://github.com/rust-lang/rust-analyzer/issues/18504


As requested in https://github.com/hrsh7th/cmp-nvim-lsp/pull/75#issuecomment-2530934779 , I've used the original PR's change, removed `filterText`, `sortText` and restored `documentation` field.

On top of that, I've added `command` to be resolved, as `additionalTextEdits` are resolved anyway and its a quite rare thing to use.
From https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem
```
/**
 * An optional command that is executed *after* inserting this completion.
 * *Note* that additional modifications to the current document should be
 * described with the additionalTextEdits-property.
 */
command?: Command;
```