### PR TITLE
fix: replace deprecated client.is_stopped() with colon syntax

### DIFF
--- a/lua/cmp_nvim_lsp/source.lua
+++ b/lua/cmp_nvim_lsp/source.lua
@@ -17,7 +17,7 @@ end
 ---@return boolean
 source.is_available = function(self)
   -- client is stopped.
-  if self.client.is_stopped() then
+  if self.client:is_stopped() then
     return false
   end
 
@@ -78,7 +78,7 @@ end
 ---@param callback function
 source.resolve = function(self, completion_item, callback)
   -- client is stopped.
-  if self.client.is_stopped() then
+  if self.client:is_stopped() then
     return callback()
   end
 
@@ -97,7 +97,7 @@ end
 ---@param callback function
 source.execute = function(self, completion_item, callback)
   -- client is stopped.
-  if self.client.is_stopped() then
+  if self.client:is_stopped() then
     return callback()
   end
 


### PR DESCRIPTION
## Summary

This PR fixes deprecation warnings in Neovim 0.11+ by replacing the deprecated `client.is_stopped()` method call with the new colon syntax `client:is_stopped()`.

## Changes

- Replace `client.is_stopped()` with `client:is_stopped()` in `lua/cmp_nvim_lsp/source.lua`

## Backwards Compatibility ✅

**This change is fully backwards compatible** and requires no version checks:

- **Lua syntax sugar**: `client:is_stopped()` is identical to `client.is_stopped(client)` - just cleaner syntax
- **Neovim support**: Colon syntax has been supported since Neovim 0.5+
- **Plugin requirements**: cmp-nvim-lsp requires Neovim 0.7+, which fully supports colon syntax
- **No breaking changes**: All functionality remains identical, only the syntax is modernized

## Background

In Neovim 0.11+, the LSP client API has deprecated the dot notation for client methods in favor of colon notation. The deprecated `client.is_stopped()` method generates warnings like:

```
client.is_stopped is deprecated. Feature will be removed in Nvim 0.13
ADVICE: use client:is_stopped instead.
```

This change maintains the same functionality while using the modern API and eliminates these deprecation warnings.

## Files Modified

- `lua/cmp_nvim_lsp/source.lua` - 3 instances updated

## Test Plan

- [x] All existing functionality remains unchanged
- [x] No more deprecation warnings in Neovim 0.11+
- [x] The `is_stopped()` method calls work identically with colon syntax
- [x] Backwards compatibility verified on Neovim 0.11.1