### PR TITLE
docs: extend default capabilities with cmp ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ require'cmp'.setup {
 }
 
 -- The nvim-cmp almost supports LSP's capabilities so You should advertise it to LSP servers..
-local capabilities = require('cmp_nvim_lsp').default_capabilities()
+local default_caps = vim.lsp.protocol.make_client_capabilities()
+local cmp_caps = require("cmp_nvim_lsp").default_capabilities()
+local capabilities = vim.tbl_deep_extend("force", default_caps, cmp_caps)
 
 -- An example for configuring `clangd` LSP to use nvim-cmp as a completion engine
 require('lspconfig').clangd.setup {


### PR DESCRIPTION
The `default_capabilities()` function does only return the `textDocument.completion` subset of capabilities. The correct approach to advertise the full set of nvim-cmp's capabilities to the LSP servers is to first get the default set of capabilities, and then extend it with the subset returned by the function. Use this approach in the documentation.