### PR TITLE
chore: update docs to use vim.lsp.config instead of require('lspconfig')

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ require'cmp'.setup {
 local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
 -- An example for configuring `clangd` LSP to use nvim-cmp as a completion engine
-require('lspconfig').clangd.setup {
+vim.lsp.config('clangd', {
   capabilities = capabilities,
   ...  -- other lspconfig configs
-}
+})
 ```
 
 ## Option

--- a/doc/cmp-nvim-lsp.txt
+++ b/doc/cmp-nvim-lsp.txt
@@ -15,11 +15,11 @@ How to disable specific LSP server's cmpletion?~
   You can disable specific LSP server's cmpletion by adding the following
 
 >
-  require('lspconfig')[%YOUR_LSP_SERVER%].setup {
+  vim.lsp.config([%YOUR_LSP_SERVER%], {
     on_attach = function(client)
       client.server_capabilities.completionProvider = false
     end
-  }
+  })
 <
 
 


### PR DESCRIPTION
This is due to https://github.com/neovim/nvim-lspconfig/pull/4077.
I've tested the config in my own LSP configs.